### PR TITLE
feat(web): add copy/paste support for dashboard

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -45,6 +45,47 @@ function showToast(message, type = 'success') {
 }
 
 /**
+ * Copy text to clipboard with fallback for non-HTTPS
+ */
+function copyToClipboard(text) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(() => {
+      showToast('Copied to clipboard', 'success');
+    }).catch(() => {
+      copyToClipboardFallback(text);
+    });
+  } else {
+    copyToClipboardFallback(text);
+  }
+}
+
+/**
+ * Fallback copy using textarea + execCommand (works on HTTP)
+ */
+function copyToClipboardFallback(text) {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.left = '-9999px';
+  textarea.style.top = '0';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  try {
+    const success = document.execCommand('copy');
+    if (success) {
+      showToast('Copied to clipboard', 'success');
+    } else {
+      showToast('Copy failed', 'error');
+    }
+  } catch (err) {
+    console.error('Copy fallback failed:', err);
+    showToast('Copy failed', 'error');
+  }
+  document.body.removeChild(textarea);
+}
+
+/**
  * Close any open actions menu
  */
 function closeActionsMenu() {
@@ -1602,9 +1643,27 @@ function createTerminalPanel(session) {
   title.textContent = displayName;
   title.title = 'Click to rename';
 
-  // Make title editable on click
+  // Track if we just copied text (to skip click handler)
+  let justCopied = false;
+
+  // Handle text selection on mouseup (before click clears it)
+  title.addEventListener('mouseup', (e) => {
+    const selection = window.getSelection();
+    if (selection && selection.toString().trim().length > 0) {
+      e.stopPropagation();
+      justCopied = true;
+      copyToClipboard(selection.toString());
+      // Reset flag after a tick (after click event fires)
+      setTimeout(() => { justCopied = false; }, 0);
+    }
+  });
+
+  // Make title editable on click (but allow text selection)
   title.addEventListener('click', (e) => {
     e.stopPropagation();
+    if (justCopied) {
+      return; // Selection was handled by mouseup
+    }
     makeEditableTitle(title, session);
   });
 
@@ -1680,7 +1739,16 @@ function createTerminalPanel(session) {
   panel.appendChild(container);
 
   // Focus handling (Ctrl+click toggles visibility filter)
+  // Skip if clicking in terminal area (let xterm handle it)
   panel.addEventListener('click', (e) => {
+    // Don't interfere with terminal clicks
+    if (e.target.closest('.terminal-container')) {
+      return;
+    }
+    const selection = window.getSelection();
+    if (selection && selection.toString().trim().length > 0) {
+      return; // Selection handled by child mouseup handlers
+    }
     if (e.ctrlKey || e.metaKey) {
       e.preventDefault();
       toggleSessionVisibility(key);
@@ -1689,10 +1757,11 @@ function createTerminalPanel(session) {
     }
   });
 
-  // Double-click to toggle fullscreen
+  // Double-click to toggle fullscreen (only on header, not terminal)
   panel.addEventListener('dblclick', (e) => {
-    // Don't trigger on header buttons
+    // Don't trigger on header buttons or terminal area
     if (e.target.closest('.panel-fullscreen-btn')) return;
+    if (e.target.closest('.terminal-container')) return;
     toggleFullscreen(key);
   });
 
@@ -1821,6 +1890,69 @@ function initTerminal(session) {
   term.onResize(({ cols, rows }) => {
     if (ws.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify({ type: 'resize', cols, rows }));
+    }
+  });
+
+  // Manual selection tracking since xterm.js mouse selection doesn't work with tmux
+  // Use term.element (the actual xterm DOM) to capture events
+  let selectionStart = null;
+  const termEl = term.element;
+
+  termEl.addEventListener('mousedown', (e) => {
+    if (e.shiftKey) {
+      const rect = termEl.getBoundingClientRect();
+      const cellWidth = rect.width / term.cols;
+      const cellHeight = rect.height / term.rows;
+      selectionStart = {
+        col: Math.floor((e.clientX - rect.left) / cellWidth),
+        row: Math.floor((e.clientY - rect.top) / cellHeight)
+      };
+    }
+  });
+
+  termEl.addEventListener('mouseup', (e) => {
+    if (selectionStart && e.shiftKey) {
+      const rect = termEl.getBoundingClientRect();
+      const cellWidth = rect.width / term.cols;
+      const cellHeight = rect.height / term.rows;
+      const endCol = Math.floor((e.clientX - rect.left) / cellWidth);
+      const endRow = Math.floor((e.clientY - rect.top) / cellHeight);
+
+      // Determine start and end positions
+      const startRow = Math.min(selectionStart.row, endRow);
+      const startCol = selectionStart.row < endRow ? selectionStart.col :
+                       selectionStart.row > endRow ? endCol :
+                       Math.min(selectionStart.col, endCol);
+
+      // Build selection text manually from buffer
+      let text = '';
+      const rowStart = Math.min(selectionStart.row, endRow);
+      const rowEnd = Math.max(selectionStart.row, endRow);
+
+      for (let r = rowStart; r <= rowEnd; r++) {
+        const line = term.buffer.active.getLine(r);
+        if (line) {
+          const lineText = line.translateToString();
+          if (r === rowStart && r === rowEnd) {
+            // Single line selection
+            const cStart = Math.min(selectionStart.col, endCol);
+            const cEnd = Math.max(selectionStart.col, endCol);
+            text += lineText.substring(cStart, cEnd);
+          } else if (r === rowStart) {
+            text += lineText.substring(selectionStart.row < endRow ? selectionStart.col : endCol) + '\n';
+          } else if (r === rowEnd) {
+            text += lineText.substring(0, selectionStart.row < endRow ? endCol : selectionStart.col);
+          } else {
+            text += lineText + '\n';
+          }
+        }
+      }
+
+      if (text.trim().length > 0) {
+        copyToClipboard(text.trim());
+      }
+
+      selectionStart = null;
     }
   });
 
@@ -2113,8 +2245,26 @@ function updateSidebar(tmuxSessions, instances = []) {
       item.appendChild(dot);
       item.appendChild(info);
 
+      // Track if we just copied text (to skip click handler)
+      let justCopied = false;
+
+      // Handle text selection on mouseup (before click clears it)
+      info.addEventListener('mouseup', (e) => {
+        const selection = window.getSelection();
+        if (selection && selection.toString().trim().length > 0) {
+          e.stopPropagation();
+          justCopied = true;
+          copyToClipboard(selection.toString());
+          // Reset flag after a tick (after click event fires)
+          setTimeout(() => { justCopied = false; }, 0);
+        }
+      });
+
       // Click to focus, Ctrl+click to toggle filter
       item.addEventListener('click', (e) => {
+        if (justCopied) {
+          return; // Selection was handled by mouseup
+        }
         if (e.ctrlKey || e.metaKey) {
           e.preventDefault();
           toggleSessionVisibility(key);

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -12,7 +12,7 @@
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-web-links@0.9.0/lib/xterm-addon-web-links.min.js"></script>
 
-  <link rel="stylesheet" href="style.css?v=5">
+  <link rel="stylesheet" href="style.css?v=6">
 </head>
 <body>
   <div id="app">
@@ -34,6 +34,6 @@
     <main id="terminal-grid"></main>
   </div>
 
-  <script src="app.js?v=5"></script>
+  <script src="app.js?v=6"></script>
 </body>
 </html>

--- a/src/web/public/style.css
+++ b/src/web/public/style.css
@@ -248,6 +248,7 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  user-select: text;
 }
 
 .session-branch {
@@ -256,6 +257,7 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  user-select: text;
 }
 
 .sidebar-footer {
@@ -862,6 +864,7 @@ body {
   transition: background 0.15s;
   flex: 0 1 auto;
   max-width: 150px;
+  user-select: text;
 }
 
 .panel-title:hover {


### PR DESCRIPTION
## Summary

- Add auto-copy on text selection in sidebar (session names, branches)
- Add auto-copy on text selection in panel headers  
- Add Shift+drag copy for terminal content (bypasses tmux mouse mode)
- Add clipboard fallback using execCommand for HTTP connections

## How it works

**Sidebar/Headers:** Select text with mouse → auto-copies on mouseup

**Terminal:** Hold Shift + drag to select → reads directly from xterm.js buffer (necessary because tmux mouse mode intercepts normal selection)

## Test plan

- [ ] Select text in sidebar session name → verify toast + clipboard
- [ ] Select text in panel header → verify toast + clipboard
- [ ] Shift+drag in terminal → verify toast + clipboard
- [ ] Test on HTTP (not just localhost) → verify fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)