### PR TITLE
feat: add --main flag and worktree toggle

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -104,10 +104,11 @@ program
   .option('-r, --repo <path>', 'Repository path (default: current directory)')
   .option('-b, --branches <branches>', 'Comma-separated branch names')
   .option('-m, --mode <mode>', 'AI mode: claude, gemini, codex, shell', 'claude')
+  .option('--main', 'Work directly on main branch (no worktree)')
   .option('--no-worktree', 'Disable automatic worktree creation')
   .option('--no-attach', 'Do not attach to tmux session after starting')
   .action(async (options) => {
-    const { count, repo, branches, mode, attach, worktree } = options
+    const { count, repo, branches, mode, attach, worktree, main } = options
 
     // Validate inputs
     if (count < 1 || count > 12) {
@@ -117,7 +118,7 @@ program
 
     // Default to current directory if not specified
     const repoPath = resolve(repo || '.')
-    const useWorktrees = worktree !== false // default true
+    const useWorktrees = worktree !== false && !main // default true, disabled by --main or --no-worktree
 
     // Check if tmux is available
     if (!TmuxRenderer.isAvailable()) {

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -909,6 +909,12 @@ function showNewSessionDialog(instanceId) {
       <div class="dialog-instance" style="font-size:0.75rem;color:#9b59b6;margin-bottom:16px;">${instanceId}</div>
       <div class="new-session-form" style="display:flex;flex-direction:column;gap:12px;">
         <div>
+          <label style="font-size:0.75rem;color:#888;display:flex;align-items:center;gap:8px;cursor:pointer;">
+            <input type="checkbox" class="new-session-use-worktree" checked style="width:16px;height:16px;accent-color:#9b59b6;">
+            <span>Use worktree (separate branch)</span>
+          </label>
+        </div>
+        <div class="branch-input-container">
           <label style="font-size:0.75rem;color:#888;display:block;margin-bottom:4px;">Branch name (optional)</label>
           <input type="text" class="new-session-branch" placeholder="Auto-generated if empty" style="width:100%;background:#0d0d0d;border:1px solid #333;color:#e0e0e0;font-size:0.85rem;padding:8px 12px;border-radius:4px;box-sizing:border-box;">
         </div>
@@ -929,10 +935,26 @@ function showNewSessionDialog(instanceId) {
     </div>
   `;
 
+  const useWorktreeCheckbox = overlay.querySelector('.new-session-use-worktree');
+  const branchInputContainer = overlay.querySelector('.branch-input-container');
   const branchInput = overlay.querySelector('.new-session-branch');
   const modeSelect = overlay.querySelector('.new-session-mode');
   const createBtn = overlay.querySelector('.new-session-create');
   const cancelBtn = overlay.querySelector('.new-session-cancel');
+
+  // Toggle branch input visibility based on worktree checkbox
+  const updateBranchInputState = () => {
+    if (useWorktreeCheckbox.checked) {
+      branchInputContainer.style.opacity = '1';
+      branchInputContainer.style.pointerEvents = 'auto';
+      branchInput.disabled = false;
+    } else {
+      branchInputContainer.style.opacity = '0.5';
+      branchInputContainer.style.pointerEvents = 'none';
+      branchInput.disabled = true;
+    }
+  };
+  useWorktreeCheckbox.addEventListener('change', updateBranchInputState);
 
   const closeDialog = () => overlay.remove();
 
@@ -949,7 +971,7 @@ function showNewSessionDialog(instanceId) {
     }
 
     try {
-      await createSession(instanceId, branchInput.value, modeSelect.value);
+      await createSession(instanceId, branchInput.value, modeSelect.value, useWorktreeCheckbox.checked);
       closeDialog();
       // Trigger refresh to show new session
       await render();
@@ -1683,7 +1705,7 @@ async function cloneAndCreateInstance(githubUrl) {
 /**
  * Create a new session via API
  */
-async function createSession(instanceId, branch, mode) {
+async function createSession(instanceId, branch, mode, useWorktree = true) {
   const res = await fetch('/api/sessions', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -1691,6 +1713,7 @@ async function createSession(instanceId, branch, mode) {
       instanceId,
       branch: branch || undefined,
       mode: mode || 'claude',
+      useWorktree,
     }),
   });
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -207,10 +207,11 @@ export class WebDashboardServer {
     // API: Create a new session
     this.app.post('/api/sessions', async (req, res) => {
       try {
-        const { instanceId, branch, mode } = req.body as {
+        const { instanceId, branch, mode, useWorktree } = req.body as {
           instanceId: string
           branch?: string
           mode?: 'claude' | 'gemini' | 'codex' | 'shell'
+          useWorktree?: boolean
         }
 
         if (!instanceId) {
@@ -236,17 +237,23 @@ export class WebDashboardServer {
         const manager = new SessionManager({ repoPath: instance.repoPath, statusDir })
         await manager.start()
 
-        // Determine branch name
-        let sessionBranch = branch?.trim() || undefined
-        if (!sessionBranch) {
-          // Auto-generate branch name
-          const existingMetadata = await loadSessionStore(instanceId)
-          const sessionIdx = existingMetadata.length
-          const timestamp = new Date().toISOString().slice(0, 10).replace(/-/g, '')
-          sessionBranch = `orcha/session-${sessionIdx + 1}-${timestamp}`
+        // Determine branch name (only if using worktrees)
+        const shouldUseWorktree = useWorktree !== false // default true
+        let sessionBranch: string | undefined = undefined
+
+        if (shouldUseWorktree) {
+          sessionBranch = branch?.trim() || undefined
+          if (!sessionBranch) {
+            // Auto-generate branch name
+            const existingMetadata = await loadSessionStore(instanceId)
+            const sessionIdx = existingMetadata.length
+            const timestamp = new Date().toISOString().slice(0, 10).replace(/-/g, '')
+            sessionBranch = `orcha/session-${sessionIdx + 1}-${timestamp}`
+          }
         }
 
-        console.log(`[API] Creating session: ${sessionBranch} (mode=${mode || 'claude'})`)
+        const branchDisplay = sessionBranch || '(no worktree)'
+        console.log(`[API] Creating session: ${branchDisplay} (mode=${mode || 'claude'})`)
 
         // Create session (this creates worktree)
         const session = await manager.createSession({


### PR DESCRIPTION
## Summary
- Add `--main` CLI flag as intuitive alias for `--no-worktree`
- Add `useWorktree` parameter to POST `/api/sessions` endpoint  
- Add "Use worktree" checkbox in web UI new session dialog

## Why?
Makes it easier to start sessions that work directly on the main branch without creating worktrees - useful for smaller tools/projects where branch isolation isn't needed.

## Test plan
- [ ] CLI: `orcha start -n 1 --main` creates session without worktree
- [ ] Web UI: Uncheck "Use worktree", create session, verify it works in repo root
- [ ] Checkbox disables/greys out branch input when unchecked

🤖 Generated with [Claude Code](https://claude.com/claude-code)