### PR TITLE
feat(web): add plan viewer button to session headers

### DIFF
--- a/docs/plan-viewer-blueprint.md
+++ b/docs/plan-viewer-blueprint.md
@@ -1,0 +1,243 @@
+# Blueprint: Plan Viewer Button in Session Header
+
+## Goal
+
+Add a "View Plan" button to session panel headers that opens a dialog showing the markdown plan file associated with that session. Plans live in the **worktree** (not session metadata), so they survive context clears.
+
+## Non-Goals (Out of Scope)
+
+- Live editing of plans from the dialog (read-only view)
+- Plan generation or modification from the UI
+- Plan history/versioning
+- Dashboard settings UI (config via file only)
+- Complex auto-detection heuristics
+
+## Acceptance Criteria
+
+1. **Convention**: Plans are stored at `.claude/plan.md` in the worktree (gitignored)
+2. **Config Override**: Optional `.orcha/config.json` can specify custom `planPath`
+3. **API Endpoint**: `GET /api/sessions/:instanceId/:sessionId/plan` returns plan content (or 404 if no plan)
+4. **Header Button**: Each session panel header shows a "📋" button (only when plan file exists)
+5. **Dialog Display**: Clicking the button opens a modal showing the plan markdown, rendered with basic styling
+6. **Context Survival**: Plan persists across session clears because it's in the worktree, not session metadata
+
+## Architecture
+
+### Key Insight: Plans Live in Worktrees
+
+Plans survive context clears because they're stored in the **worktree filesystem**, not in session metadata. Each worktree = one feature branch = one plan.
+
+```
+Session cleared? No problem!
+    ↓
+Worktree still exists: ~/.orcha/worktrees/orcha/session-1-xyz/
+    ↓
+Plan still there: .claude/plan.md
+    ↓
+Dashboard reads it on demand
+```
+
+### Data Flow
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                         Web Dashboard                                 │
+├──────────────────────────────────────────────────────────────────────┤
+│                                                                       │
+│  ┌─────────────┐    click    ┌────────────────┐   fetch    ┌───────┐ │
+│  │ Plan Button │ ──────────► │ showPlanDialog │ ─────────► │ API   │ │
+│  │ (in header) │             │    (app.js)    │            │       │ │
+│  └─────────────┘             └────────────────┘            └───┬───┘ │
+│                                     ▲                          │     │
+│                                     │ { content, path }        │     │
+│                                     └──────────────────────────┘     │
+│                                                                       │
+└──────────────────────────────────────────────────────────────────────┘
+                                      │
+                                      ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                         Backend (server.ts)                          │
+├──────────────────────────────────────────────────────────────────────┤
+│                                                                       │
+│  GET /api/sessions/:instanceId/:sessionId/plan                        │
+│    1. Get worktreePath from SessionMetadata                           │
+│    2. Check for .orcha/config.json → custom planPath                  │
+│    3. Default: read {worktreePath}/.claude/plan.md                    │
+│    4. Return { content, path } or 404                                 │
+│                                                                       │
+└──────────────────────────────────────────────────────────────────────┘
+                                      │
+                                      ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                         Worktree Filesystem                          │
+├──────────────────────────────────────────────────────────────────────┤
+│                                                                       │
+│  ~/.orcha/worktrees/orcha/session-1-xyz/                              │
+│  ├── .claude/                                                         │
+│  │   └── plan.md          ← DEFAULT: plan lives here (gitignored)    │
+│  ├── .orcha/                                                          │
+│  │   └── config.json      ← OPTIONAL: { "planPath": "docs/plan.md" } │
+│  ├── src/                                                             │
+│  └── ...                                                              │
+│                                                                       │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Components Modified
+
+| Component | Changes |
+|-----------|---------|
+| `src/web/server.ts` | Add GET `/api/sessions/:id/:sid/plan` endpoint |
+| `src/web/public/app.js` | Add plan button to header, dialog to show plan |
+| `src/web/public/style.css` | Styles for plan button and plan dialog |
+
+**Note**: No changes to `session-store.ts` needed - plans live in worktree filesystem.
+
+### Plan Resolution Logic
+
+```typescript
+function resolvePlanPath(worktreePath: string): string | null {
+  // 1. Check for custom config
+  const configPath = join(worktreePath, '.orcha', 'config.json')
+  if (existsSync(configPath)) {
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'))
+    if (config.planPath) {
+      const customPath = join(worktreePath, config.planPath)
+      if (existsSync(customPath)) return customPath
+    }
+  }
+
+  // 2. Default location
+  const defaultPath = join(worktreePath, '.claude', 'plan.md')
+  if (existsSync(defaultPath)) return defaultPath
+
+  return null
+}
+```
+
+## File Layout (Key Changes)
+
+```
+src/
+├── web/
+│   ├── server.ts              # Add plan API endpoint
+│   └── public/
+│       ├── app.js             # Add plan button + dialog
+│       └── style.css          # Add plan dialog styles
+
+# In each worktree (not committed):
+.claude/
+└── plan.md                    # The plan (gitignored)
+
+# Optional config (can be committed):
+.orcha/
+└── config.json                # { "planPath": "docs/my-plan.md" }
+```
+
+## Milestones
+
+### Milestone 1: Add Plan API Endpoint
+
+**Intent**: Backend endpoint to read plan content from worktree.
+
+**Key Files**:
+- `src/web/server.ts` - Add GET `/api/sessions/:instanceId/:sessionId/plan`
+
+**Verification**:
+```bash
+# Build and test endpoint
+npm run build
+
+# Create test plan
+mkdir -p /tmp/test-worktree/.claude
+echo "# Test Plan" > /tmp/test-worktree/.claude/plan.md
+
+# Test with curl (replace with real session)
+curl http://localhost:3847/api/sessions/orcha-orcha/session-id/plan
+```
+
+---
+
+### Milestone 2: Add Plan Button to Panel Header
+
+**Intent**: Show a plan button in each session's header bar. Button visibility based on plan existence.
+
+**Key Files**:
+- `src/web/public/app.js` - Add button in `createTerminalPanel()`
+- `src/web/public/style.css` - Style the button
+
+**Verification**:
+- Visual inspection in browser
+- Button appears (can be always visible, grayed out if no plan)
+
+---
+
+### Milestone 3: Implement Plan Dialog
+
+**Intent**: Modal dialog that fetches and displays plan markdown with basic rendering.
+
+**Key Files**:
+- `src/web/public/app.js` - `showPlanDialog()` function
+- `src/web/public/style.css` - Dialog styling (reuse existing dialog patterns)
+
+**Verification**:
+- Click plan button opens dialog
+- Plan content displays with headers, lists, code blocks styled
+- Escape key or click outside closes dialog
+
+---
+
+### Milestone 4: Update /blueprint Skill
+
+**Intent**: Make /blueprint write plans to `.claude/plan.md` by convention.
+
+**Key Files**:
+- `.claude/commands/blueprint.md` - Update output path
+
+**Verification**:
+```bash
+# Run /blueprint and verify plan is written to .claude/plan.md
+ls -la .claude/plan.md
+```
+
+## Risks & Unknowns
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Plan file doesn't exist | Low | Show "No plan found" message, button still works |
+| Large plan files | Low | Add loading spinner, lazy load content |
+| Markdown rendering | Low | Simple CSS styling for pre-formatted text |
+| Sessions without worktrees | Medium | Fall back to instance repoPath |
+
+### Quick Probes
+
+1. **Markdown rendering**: Use simple CSS styling (white-space: pre-wrap) or basic regex?
+   - **Recommendation**: Start with `<pre>` styling, enhance if needed
+
+2. **Plan existence check**: Check on every render or cache?
+   - **Recommendation**: Check in `getAllSessions()`, return `hasPlan: boolean`
+
+## Implementation Notes
+
+### Button Position in Header
+The panel header currently has: `[dot] [title] [repo] [status] [⋮] [📁] [⛶] [×]`
+Add plan button after status: `[dot] [title] [repo] [status] [📋] [⋮] [📁] [⛶] [×]`
+
+### Session Info Enhancement
+The `getAllSessions()` method should return `hasPlan: boolean` flag so the frontend knows whether to show the button without extra API calls.
+
+### Gitignore Convention
+Plans should be gitignored since they're ephemeral working documents:
+```gitignore
+# In .gitignore
+.claude/plan.md
+```
+
+### CSS Class Names
+- `.panel-plan-btn` - Plan button in header
+- `.plan-dialog` - Dialog container
+- `.plan-content` - Markdown content area (styled `<pre>`)
+
+---
+
+**Next: /probe 'Milestone 1 - Add Plan API Endpoint'**

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -682,6 +682,58 @@ function showFileDiff(container, fullDiff, filePath) {
 }
 
 /**
+ * Show plan dialog - fetches and displays plan.md from session worktree
+ */
+async function showPlanDialog(session) {
+  const overlay = document.createElement('div');
+  overlay.className = 'new-session-overlay plan-dialog-overlay';
+
+  overlay.innerHTML = `
+    <div class="plan-dialog">
+      <div class="plan-dialog-header">
+        <span class="plan-dialog-title">📋 Plan: ${getSessionDisplayName(session)}</span>
+        <button class="plan-dialog-close">×</button>
+      </div>
+      <div class="plan-dialog-content">
+        <div class="plan-loading">Loading plan...</div>
+      </div>
+    </div>
+  `;
+
+  const contentEl = overlay.querySelector('.plan-dialog-content');
+  const closeBtn = overlay.querySelector('.plan-dialog-close');
+
+  const closeDialog = () => overlay.remove();
+
+  closeBtn.addEventListener('click', closeDialog);
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) closeDialog();
+  });
+  overlay.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') closeDialog();
+  });
+
+  document.body.appendChild(overlay);
+  closeBtn.focus();
+
+  // Fetch plan content
+  try {
+    const res = await fetch(`/api/sessions/${session.instanceId}/${session.id}/plan`);
+    if (!res.ok) {
+      const data = await res.json();
+      contentEl.innerHTML = `<div class="plan-empty">${data.error || 'No plan found'}</div>`;
+      return;
+    }
+
+    const data = await res.json();
+    // Render markdown as preformatted text with basic styling
+    contentEl.innerHTML = `<pre class="plan-content">${escapeHtml(data.content)}</pre>`;
+  } catch (err) {
+    contentEl.innerHTML = `<div class="plan-error">Failed to load plan: ${err.message}</div>`;
+  }
+}
+
+/**
  * Open file manager (yazi) in a modal
  */
 function openFileManager(instanceId) {
@@ -2052,6 +2104,16 @@ function createTerminalPanel(session) {
   status.className = 'panel-status';
   status.textContent = session.state;
 
+  // Plan button (view plan.md)
+  const planBtn = document.createElement('button');
+  planBtn.className = 'panel-plan-btn';
+  planBtn.innerHTML = '📋';
+  planBtn.title = 'View plan';
+  planBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    showPlanDialog(session);
+  });
+
   // Git actions menu button
   const actionsBtn = document.createElement('button');
   actionsBtn.className = 'panel-actions-btn';
@@ -2110,6 +2172,7 @@ function createTerminalPanel(session) {
   header.appendChild(title);
   header.appendChild(repo);
   header.appendChild(status);
+  header.appendChild(planBtn);
   header.appendChild(actionsBtn);
   header.appendChild(folderBtn);
   header.appendChild(reviewBtn);

--- a/src/web/public/style.css
+++ b/src/web/public/style.css
@@ -1292,6 +1292,110 @@ body {
   overflow-y: auto !important;
 }
 
+/* Plan button in panel header */
+.panel-plan-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  margin-left: 4px;
+  transition: background 0.15s, color 0.15s;
+  line-height: 1;
+}
+
+.panel-plan-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+/* Plan dialog */
+.plan-dialog-overlay {
+  z-index: 1100;
+}
+
+.plan-dialog {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  width: 70vw;
+  height: 70vh;
+  max-width: 900px;
+  max-height: 700px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+}
+
+.plan-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.plan-dialog-title {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.plan-dialog-close {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1.4rem;
+  cursor: pointer;
+  padding: 2px 8px;
+  border-radius: 4px;
+  line-height: 1;
+  transition: background 0.15s, color 0.15s;
+}
+
+.plan-dialog-close:hover {
+  background: var(--status-error);
+  color: white;
+}
+
+.plan-dialog-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+.plan-loading {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.plan-empty {
+  color: var(--text-muted);
+  font-style: italic;
+  text-align: center;
+  padding: 40px;
+}
+
+.plan-error {
+  color: var(--status-error);
+  text-align: center;
+  padding: 40px;
+}
+
+.plan-content {
+  margin: 0;
+  font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 /* Toast notifications */
 .toast-notification {
   position: fixed;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -13,7 +13,7 @@ import { join, dirname, resolve, isAbsolute } from 'path'
 import { homedir } from 'os'
 import { fileURLToPath } from 'url'
 import { execSync } from 'child_process'
-import { existsSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 import { listInstances, getInstance, getInstanceByPath, registerInstance, unregisterInstance } from '../core/instance-registry.js'
 import { StatusMonitor, getStatusDirForInstance } from '../core/status-monitor.js'
 import { loadSessionStore, updateSessionName, saveSessionStore } from '../core/session-store.js'
@@ -134,6 +134,47 @@ export class WebDashboardServer {
 
         res.json({ success: true, name: name || null })
       } catch (err) {
+        res.status(500).json({ error: (err as Error).message })
+      }
+    })
+
+    // API: Get plan content for a session
+    this.app.get('/api/sessions/:instanceId/:sessionId/plan', async (req, res) => {
+      try {
+        const { instanceId, sessionId } = req.params
+
+        // Load session metadata to get worktree path
+        const metadata = await loadSessionStore(instanceId)
+        const session = metadata.find(m => m.id === sessionId)
+
+        if (!session) {
+          res.status(404).json({ error: 'Session not found' })
+          return
+        }
+
+        // Determine base path (worktree or instance repo)
+        let basePath = session.worktreePath
+        if (!basePath) {
+          const instance = await getInstance(instanceId)
+          if (!instance) {
+            res.status(404).json({ error: 'Instance not found' })
+            return
+          }
+          basePath = instance.repoPath
+        }
+
+        // Resolve plan path
+        const planPath = this.resolvePlanPath(basePath)
+        if (!planPath) {
+          res.status(404).json({ error: 'No plan found' })
+          return
+        }
+
+        // Read plan content
+        const content = readFileSync(planPath, 'utf-8')
+        res.json({ content, path: planPath })
+      } catch (err) {
+        console.error('[API] Error reading plan:', err)
         res.status(500).json({ error: (err as Error).message })
       }
     })
@@ -1612,6 +1653,33 @@ export class WebDashboardServer {
     }
 
     return sessions
+  }
+
+  /**
+   * Resolve plan file path for a worktree/repo
+   * 1. Check for custom config in .orcha/config.json
+   * 2. Default to .claude/plan.md
+   */
+  private resolvePlanPath(basePath: string): string | null {
+    // 1. Check for custom config
+    const configPath = join(basePath, '.orcha', 'config.json')
+    if (existsSync(configPath)) {
+      try {
+        const config = JSON.parse(readFileSync(configPath, 'utf-8'))
+        if (config.planPath) {
+          const customPath = join(basePath, config.planPath)
+          if (existsSync(customPath)) return customPath
+        }
+      } catch {
+        // Invalid config, fall through to default
+      }
+    }
+
+    // 2. Default location
+    const defaultPath = join(basePath, '.claude', 'plan.md')
+    if (existsSync(defaultPath)) return defaultPath
+
+    return null
   }
 
   private async getClaudeUsage(): Promise<UsageStats | { error: string }> {


### PR DESCRIPTION
## Summary

- Add a "View Plan" button (📋) to session panel headers
- Opens a dialog showing `.claude/plan.md` from the session worktree
- Plans survive context clears since they live in worktree filesystem, not session metadata

## Changes

- **API**: `GET /api/sessions/:instanceId/:sessionId/plan` endpoint
- **Frontend**: `showPlanDialog()` function with loading/error states
- **UI**: Plan button in panel header, styled dialog with close/escape support
- **Config**: Optional custom `planPath` via `.orcha/config.json`

## Test plan

- [ ] Click 📋 button on a session with `.claude/plan.md` → dialog shows plan content
- [ ] Click 📋 button on a session without plan → shows "No plan found"
- [ ] Press Escape or click outside → dialog closes
- [ ] Custom planPath in `.orcha/config.json` is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)